### PR TITLE
Add recieve pledge hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Fraternity.configure do |config|
   configure.send_invite = lambda do |pledge|
     BetaMailer.invite_email(pledge).deliver
   end
+  config.receive_pledge = lambda do |pledge|
+    AdminMailer.new_pledge_email(pledge).deliver
+  end
 end
 ```
 
@@ -80,7 +83,7 @@ params = { email: "jeremy.piven@example.com" } # Optional attributes you want to
 pledge = Fraternity.rush! params
 ```
 
-The above saves the information to the pledges database and creates a token for a `Pledge`
+The above saves the information to the pledges database and creates a token for a `Pledge`. It calls the `receive_pledge` hook with the new `Pledge` instance that is defined in the configuration.
 
 ### Moving up the initiation line
 

--- a/lib/fraternity.rb
+++ b/lib/fraternity.rb
@@ -21,12 +21,13 @@ module Fraternity
     pledge = Repositories::PledgeRepository.find_by_email params[:email]
     if pledge
       pledge.merge params
-      pledge
     else
       params[:token] ||= TemporaryToken.generate_random_token
       params[:initiation_number] ||= Time.now.to_i
-      Fraternity::Pledge.new params
+      pledge = Fraternity::Pledge.new params
     end
+    configuration.receive_pledge.call pledge
+    pledge
   end
 
   def self.rush!(params)

--- a/lib/fraternity/configuration.rb
+++ b/lib/fraternity/configuration.rb
@@ -1,8 +1,9 @@
 module Fraternity
   class Configuration
-    attr_accessor :database_url, :send_invite
+    attr_accessor :database_url, :send_invite, :receive_pledge
 
     def initialize
+      @receive_pledge = lambda { |pledge| pledge }
       @send_invite = lambda { |pledge| pledge }
     end
   end

--- a/lib/fraternity/version.rb
+++ b/lib/fraternity/version.rb
@@ -1,3 +1,3 @@
 module Fraternity
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/fraternity/configuration_spec.rb
+++ b/spec/fraternity/configuration_spec.rb
@@ -3,4 +3,9 @@ describe Fraternity::Configuration do
     configuration = Fraternity::Configuration.new
     expect { configuration.send_invite.call(nil) }.to_not raise_error
   end
+
+  it "has a default receive_pledge proc" do
+    configuration = Fraternity::Configuration.new
+    expect { configuration.receive_pledge.call(nil) }.to_not raise_error
+  end
 end

--- a/spec/fraternity/pledge_spec.rb
+++ b/spec/fraternity/pledge_spec.rb
@@ -59,6 +59,7 @@ describe Fraternity::Pledge do
 
   describe "#cross!" do
     it "sets the date and time of when the pledge has accepted the invite to the current date and time" do
+      load_repositories!
       token = "12345"
       pledge = Fraternity::Pledge.new token: token, invited_at: DateTime.now
       pledge.cross! token

--- a/spec/fraternity_spec.rb
+++ b/spec/fraternity_spec.rb
@@ -51,6 +51,8 @@ describe Fraternity do
   end
 
   describe ".rush" do
+    before { load_repositories! }
+
     it "rushes with parameters that describe the pledge" do
       expect { Fraternity.rush email: "blah" }.to_not raise_error
     end
@@ -75,6 +77,17 @@ describe Fraternity do
       expect(pledge.initiation_number).to_not be_nil
       initiated_at = Time.at pledge.initiation_number
       expect((Time.now - initiated_at).to_i).to be < 1
+    end
+
+    it "calls the receive pledge hook" do
+      receive_pledge = false
+      Fraternity.configure(false) do |c|
+        c.receive_pledge = lambda do |pledge|
+          receive_pledge = true
+        end
+      end
+      pledges = Fraternity.rush
+      expect(receive_pledge).to be true
     end
 
     it "uses the provided initiation number if there is one" do


### PR DESCRIPTION
Allows the client application to setup a `lambda` so that it can do anything with any new `Pledge`s. This is useful in order to alert your systems that a new user has signed up.

In order to use it, set it up in the configuration.

```
Fraternity.configure do |c|
  c.receive_pledge = lambda do |pledge|
    # Do stuff here
  end
end
```
